### PR TITLE
Added migration for game-to-console mapping and analytics in 20260604…

### DIFF
--- a/app/controllers/registration_controller.py
+++ b/app/controllers/registration_controller.py
@@ -49,10 +49,14 @@ def update_payment_status(event_id, registration_id):
     Event.query.filter_by(id=event_id, vendor_id=vid).first_or_404()
     payload = request.get_json() or {}
     status = payload.get("payment_status")
-    if status not in {"pending", "paid", "failed"}:
+    if status not in {"pending", "paid", "failed", "refunded"}:
         return jsonify({"error": "Invalid payment_status"}), 400
     reg = Registration.query.filter_by(id=registration_id, event_id=event_id).first_or_404()
     reg.payment_status = status
+    if status == "paid":
+        reg.status = "confirmed"
+    elif status in {"failed", "refunded"} and reg.status == "confirmed":
+        reg.status = "pending"
     db.session.commit()
     try:
         socketio.emit("tournaments_updated", {"vendor_id": vid}, room=f"vendor_{vid}")


### PR DESCRIPTION
…_game_discovery_catalog.sql (line 1).

Added app game APIs in vendor_games.py (line 24):GET /api/games/platforms GET /api/games/popular?console_slug=pc&city=Hyderabad GET /api/games/search?console_slug=pc&q=valorant
POST /api/games/discovery-events

Added cached discovery/query logic in game_service.py (line 10). Kept existing /api/games untouched for legacy/admin use. Documented the app flow in frontend-api.md (line 138). Migration Notes
Maps PC/Linux/macOS/Web/Classic Macintosh -> pc
Maps PlayStation 2/3/4/5/PS Vita -> playstation
Maps Xbox/Xbox One/Xbox 360/Xbox Series S/X -> xbox Maps Nintendo Switch -> nintendo_switch
Leaves Android/iOS/Dreamcast/SEGA/GameCube/Wii U/Nintendo DS unmapped for now because your console_catalog has no matching active category.