### PR TITLE
Backend hfg-dashboard-service now derives status from tournament date…

### DIFF
--- a/app/controllers/event_controller.py
+++ b/app/controllers/event_controller.py
@@ -2,7 +2,7 @@ from flask import Blueprint, request, jsonify, current_app
 import time, datetime
 import jwt  # PyJWT
 from flask_jwt_extended import jwt_required, get_jwt
-from app.services.event_service import create_event, list_events, update_event
+from app.services.event_service import create_event, list_events, update_event, sync_event_status
 from app.services.cloudinary_event_service import CloudinaryEventImageService
 from app.services.tournament_engine_service import list_matches
 from app.services.websocket_service import socketio
@@ -21,6 +21,7 @@ def _vendor_id():
 
 
 def _event_payload(e):
+    sync_event_status(e)
     return {
         "id": str(e.id),
         "title": e.title,
@@ -183,6 +184,8 @@ def get_events():
 def get_event(event_id):
     vid = _vendor_id()
     event = Event.query.filter_by(id=event_id, vendor_id=vid).first_or_404()
+    if sync_event_status(event):
+        db.session.commit()
     return jsonify(_event_payload(event)), 200
 
 
@@ -191,6 +194,8 @@ def get_event(event_id):
 def get_event_detail(event_id):
     vid = _vendor_id()
     event = Event.query.filter_by(id=event_id, vendor_id=vid).first_or_404()
+    if sync_event_status(event):
+        db.session.commit()
     return jsonify({
         "event": _event_payload(event),
         "registrations": _registration_payloads(event_id),

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -1,7 +1,76 @@
+from datetime import datetime, timezone
+
 from app.extension.extensions import db
 from app.models.event import Event, EventStatus
 
+
+TERMINAL_STATUSES = {EventStatus.DRAFT, EventStatus.COMPLETED, EventStatus.CANCELED}
+
+
+def _as_aware_datetime(value):
+    if value is None or isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    else:
+        return value
+
+    if parsed and parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _normalize_datetime_fields(payload):
+    normalized = dict(payload or {})
+    for key in (
+        "start_at",
+        "end_at",
+        "registration_deadline",
+        "check_in_starts_at",
+        "check_in_ends_at",
+    ):
+        if key in normalized and normalized[key]:
+            normalized[key] = _as_aware_datetime(normalized[key])
+    return normalized
+
+
+def derive_event_status(event, now=None):
+    status = event.status or EventStatus.DRAFT
+    if status in TERMINAL_STATUSES:
+        return status
+
+    start_at = _as_aware_datetime(event.start_at)
+    end_at = _as_aware_datetime(event.end_at)
+    current_time = now or datetime.now(timezone.utc)
+
+    if not start_at or not end_at:
+        return status
+    if current_time > end_at:
+        return EventStatus.COMPLETED
+    if current_time >= start_at:
+        return EventStatus.ONGOING
+    return EventStatus.PUBLISHED
+
+
+def sync_event_status(event, now=None):
+    next_status = derive_event_status(event, now)
+    changed = event.status != next_status
+    if changed:
+        event.status = next_status
+    return changed
+
+
+def sync_event_statuses(events):
+    changed = False
+    now = datetime.now(timezone.utc)
+    for event in events:
+        changed = sync_event_status(event, now) or changed
+    if changed:
+        db.session.commit()
+    return events
+
 def create_event(vendor_id, payload):
+    payload = _normalize_datetime_fields(payload)
     ev = Event(
         vendor_id=vendor_id,
         title=payload["title"],
@@ -34,20 +103,25 @@ def create_event(vendor_id, payload):
         banner_image_url=payload.get("banner_image_url"),
         banner_public_id=payload.get("banner_public_id"),
     )
+    sync_event_status(ev)
     db.session.add(ev)
     db.session.commit()
     return ev
 
 def list_events(vendor_id, status=None):
     q = Event.query.filter_by(vendor_id=vendor_id)
+    events = q.order_by(Event.created_at.desc()).all()
+    sync_event_statuses(events)
     if status:
-        q = q.filter(Event.status == status)
-    return q.order_by(Event.created_at.desc()).all()
+        events = [event for event in events if event.status == status]
+    return events
 
 def update_event(vendor_id, event_id, patch):
+    patch = _normalize_datetime_fields(patch)
     ev = Event.query.filter_by(id=event_id, vendor_id=vendor_id).first_or_404()
     for k, v in patch.items():
         if hasattr(ev, k):
             setattr(ev, k, v)
+    sync_event_status(ev)
     db.session.commit()
     return ev


### PR DESCRIPTION
…s on create/list/get/detail/update:

before start_at -> published
between start_at and end_at -> ongoing
after end_at -> completed
preserves intentional draft, completed, and canceled See [event_service.py (line 37)](/Users/bhanujoshi/Documents/Hash/hfg-dashboard-service/app/services/event_service.py:37) and [event_controller.py (line 182)](/Users/bhanujoshi/Documents/Hash/hfg-dashboard-service/app/controllers/event_controller.py:182)